### PR TITLE
Increment version number to 0.1.3.9001

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nhppp
 Title: Simulating Nonhomogeneous Poisson Point Processes 
-Version: 0.1.3.9000
+Version: 0.1.3.9001
 Authors@R: 
     c(person(given = "Thomas", 
              family = "Trikalinos", 

--- a/R/utils-helper.R
+++ b/R/utils-helper.R
@@ -84,7 +84,7 @@ check_ppp_sample_validity <- function(times, t_min, t_max = NULL, size = NULL, a
     check_ppp_vector_validity(times = times, t_min = t_min, t_max = t_max, size = size, atmost1 = atmost1, atleast1 = atleast1)
   } else {
     for (i in 1:nrow(times)) {
-      expect_identical(times[i, !is.na(times[i, ])], sort(times[i, ], na.last = NA))
+      testthat::expect_identical(times[i, !is.na(times[i, ])], sort(times[i, ], na.last = NA))
       check_ppp_vector_validity(times = times[i, ], t_min = t_min, t_max = t_max, size = size, atmost1 = atmost1, atleast1 = atleast1)
     }
   }


### PR DESCRIPTION
amendment to remove NOTE about a global function missing `testthat::` in `check_ppp_sample()` 